### PR TITLE
7 handle prompt failure

### DIFF
--- a/packages/cli/src/ezsam/process.py
+++ b/packages/cli/src/ezsam/process.py
@@ -183,7 +183,19 @@ def process_image(
   detections.xyxy = detections.xyxy[nms_idx]
   detections.confidence = detections.confidence[nms_idx]
   detections.class_id = detections.class_id[nms_idx]
-  print(f'{now()} After NMS: {len(detections.xyxy)} boxes')
+  num_detections = len(detections.xyxy)
+  print(f'{now()} After NMS: {num_detections} boxes')
+
+  if num_detections <= 0:
+    if debug:
+      print(f'Warning: no objects detected for prompts {prompts}, returning original image ...')
+      return image
+    else:
+      print(f'Warning: no objects detected for prompts {prompts}, returning empty image ...')
+      # Create a new image with dimensions of old image plus an alpha channel, and then zero out everything
+      processed_image = cv2.cvtColor(image, cv2.COLOR_BGR2BGRA)
+      processed_image[:, :, :] = 0
+      return processed_image
 
   import segment_anything_hq as samhq
 


### PR DESCRIPTION
Gracefully handles prompts resulting in no object detections. In debug mode this means the original image is returned. In filter mode, an empty image of the same size as the input image is returned. An error should not be thrown, just a warning, since it's conceivable that a user passes a video with the subject(s) moving in and out of frame.

Also fixes issue where sometimes supervision annotators used in debug mode would seemingly randomly fail, due to the color_lookup mode not being set to ColorLookup.INDEX as is required for annotating SAM detections.
https://github.com/roboflow/notebooks/blob/main/notebooks/how-to-segment-anything-with-sam.ipynb
https://supervision.roboflow.com/annotators/

Fixes #7 