### PR TITLE
8-cuda-out-of-memory

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,4 @@ CUDA_HOME=/usr/local/cuda
 CUDA_VISIBLE_DEVICES=0
 # Another option to try and avoid CUDA out of memory issues
 # ref: https://pytorch.org/docs/stable/notes/cuda.html#environment-variables
-#PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
+PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512

--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@ AM_I_DOCKER=False
 BUILD_WITH_CUDA=True
 CUDA_HOME=/usr/local/cuda
 CUDA_VISIBLE_DEVICES=0
+# Another option to try and avoid CUDA out of memory issues
+# ref: https://pytorch.org/docs/stable/notes/cuda.html#environment-variables
+#PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512

--- a/packages/cli/src/ezsam/lib/gpu.py
+++ b/packages/cli/src/ezsam/lib/gpu.py
@@ -1,0 +1,9 @@
+import gc
+import torch
+
+
+def attempt_gpu_cleanup():
+  if torch.cuda.is_available():
+    print('Attempting GPU memory cleanup ...')
+    torch.cuda.empty_cache()
+    gc.collect()


### PR DESCRIPTION
CUDA OOM errors can happen even when using models and running on images that previously worked. (Larger models and images do seem to cause OOM more often as expected.) For videos, number of frames in a video to be processed doesn't seem to matter (if frame one processes, they all do).

Without rewriting the underlying libraries (which call pytorch), perhaps not too much can be done, but this PR at least tries to get pytorch to clear use of gpu memory before and after all gpu operations via torch.cuda.empty_cache(), and explicitly deleting some pytorch-related objects and calling garbage collection.

Also adds an option to show PyTorch CUDA memory usage when exiting.