### PR TITLE
20 cache folder

### DIFF
--- a/src/ezsam/cli/app.py
+++ b/src/ezsam/cli/app.py
@@ -199,7 +199,7 @@ def main(argv=None):
   if not GD_CHECKPOINT:
     gd_checkpoint_path, gd_downloaded = get_cached_model_or_download(Model.gd)
   if not SAM_CHECKPOINT:
-    sam_checkpoint_path, sam_downloaded = get_cached_model_or_download(Model.gd)
+    sam_checkpoint_path, sam_downloaded = get_cached_model_or_download(model_name)
   something_downloaded = gd_downloaded or sam_downloaded
 
   for checkpoint in [gd_checkpoint_path, sam_checkpoint_path]:

--- a/src/ezsam/cli/app.py
+++ b/src/ezsam/cli/app.py
@@ -186,6 +186,7 @@ def main(argv=None):
       # Check if we have a cached file
       if os.path.isfile(path):
         checkpoint_path = path
+        break
     # No cached file, so set a default location and download
     if not checkpoint_path and len(default_checkpoint_paths) > 0:
       checkpoint_path = default_checkpoint_paths[0]

--- a/src/ezsam/cli/app.py
+++ b/src/ezsam/cli/app.py
@@ -23,7 +23,7 @@ from ezsam.lib.gpu import attempt_gpu_cleanup
 from ezsam.cli.models import Model, MODEL_URL, get_default_paths_from_model
 from ezsam.cli.formats import OutputImageFormat, OutputVideoCodec
 from ezsam.cli.process import process_file
-from ezsam.cli.config.utils import cleanup_gdconfig_tmpfile, create_gdconfig_tmpfile
+from ezsam.cli.config.utils import create_gdconfig_file
 from ezsam.cli.config.defaults import (
   DEFAULT_SAM_MODEL,
   DEFAULT_GROUNDING_DINO_CONFIG_PATH,
@@ -162,10 +162,9 @@ def main(argv=None):
     os.makedirs(OUTPUT_DIR)
 
   # If GroundingDINO config file doesn't exist already, create config in cache location
-  using_gdconfig_tmpfile = False
   if not os.path.isfile(GD_CONFIG_PATH):
     print(f'Warning: No GroundingDINO config at: {GD_CONFIG_PATH}')
-    GD_CONFIG_PATH = create_gdconfig_tmpfile()
+    GD_CONFIG_PATH = create_gdconfig_file()
 
   sam_checkpoint_path = SAM_CHECKPOINT
   gd_checkpoint_path = GD_CHECKPOINT
@@ -264,8 +263,6 @@ def main(argv=None):
   except Exception as err:
     print(err)
   finally:
-    if using_gdconfig_tmpfile:
-      cleanup_gdconfig_tmpfile()
     del grounding_dino_model
     del sam_predictor
     del sam

--- a/src/ezsam/cli/config/defaults.py
+++ b/src/ezsam/cli/config/defaults.py
@@ -3,7 +3,7 @@ import pathlib
 from ezsam.cli.formats import OutputImageFormat, OutputVideoCodec
 
 HOME_FOLDER = pathlib.Path.home().as_posix()
-DEFAULT_CACHE_FOLDER_LOCATION = f'{HOME_FOLDER}/.config/ezsam'
+DEFAULT_CACHE_FOLDER_LOCATION = f'{HOME_FOLDER}/.cache/ezsam'
 DEFAULT_GROUNDING_DINO_CONFIG_PATH = f'{DEFAULT_CACHE_FOLDER_LOCATION}/GroundingDINO_SwinT_OGC.py'
 DEFAULT_SAM_MODEL = 'vit_h'
 DEFAULT_OUTPUT_DIR = '.'

--- a/src/ezsam/cli/config/defaults.py
+++ b/src/ezsam/cli/config/defaults.py
@@ -4,9 +4,8 @@ from ezsam.cli.formats import OutputImageFormat, OutputVideoCodec
 
 HOME_FOLDER = pathlib.Path.home().as_posix()
 DEFAULT_CACHE_FOLDER_LOCATION = f'{HOME_FOLDER}/.config/ezsam'
+DEFAULT_GROUNDING_DINO_CONFIG_PATH = f'{DEFAULT_CACHE_FOLDER_LOCATION}/GroundingDINO_SwinT_OGC.py'
 DEFAULT_SAM_MODEL = 'vit_h'
-DEFAULT_GROUNDING_DINO_CONFIG_PATH = './config/GroundingDINO_SwinT_OGC.py'
-DEFAULT_GROUNDING_DINO_CONFIG_PATH_TMP = '.gdconf.py'
 DEFAULT_OUTPUT_DIR = '.'
 DEFAULT_OUTPUT_SUFFIX = '.out'
 DEFAULT_BOX_THRESHOLD = 0.3

--- a/src/ezsam/cli/config/defaults.py
+++ b/src/ezsam/cli/config/defaults.py
@@ -1,6 +1,9 @@
+import pathlib
+
 from ezsam.cli.formats import OutputImageFormat, OutputVideoCodec
 
-
+HOME_FOLDER = pathlib.Path.home().as_posix()
+DEFAULT_CACHE_FOLDER_LOCATION = f'{HOME_FOLDER}/.config/ezsam'
 DEFAULT_SAM_MODEL = 'vit_h'
 DEFAULT_GROUNDING_DINO_CONFIG_PATH = './config/GroundingDINO_SwinT_OGC.py'
 DEFAULT_GROUNDING_DINO_CONFIG_PATH_TMP = '.gdconf.py'

--- a/src/ezsam/cli/config/utils.py
+++ b/src/ezsam/cli/config/utils.py
@@ -29,8 +29,7 @@ def cleanup_gdconfig_file(src=DEFAULT_GROUNDING_DINO_CONFIG_PATH):
     os.remove(sane)
 
 
-DEFAULT_GD_CONFIG = '''
-batch_size = 1
+DEFAULT_GD_CONFIG = '''batch_size = 1
 modelname = 'groundingdino'
 backbone = 'swin_T_224_1k'
 position_embedding = 'sine'

--- a/src/ezsam/cli/config/utils.py
+++ b/src/ezsam/cli/config/utils.py
@@ -4,24 +4,29 @@
 import os
 
 from ezsam.cli.config.defaults import (
-  DEFAULT_GROUNDING_DINO_CONFIG_PATH_TMP,
+  DEFAULT_GROUNDING_DINO_CONFIG_PATH,
 )
 
 
-def create_gdconfig_tmpfile(src=DEFAULT_GROUNDING_DINO_CONFIG_PATH_TMP):
-  print(f'Creating temp GroundingDINO config file at: {src} ...')
-  with open(src, 'w') as f:
+def create_gdconfig_file(src=DEFAULT_GROUNDING_DINO_CONFIG_PATH):
+  sane = os.path.abspath(os.path.normpath(src))
+  print(f'Creating GroundingDINO config file at: {sane} ...')
+  outdir = os.path.dirname(sane)
+  if not os.path.exists(outdir):
+    os.makedirs(outdir)
+  with open(sane, 'w') as f:
     f.write(str(DEFAULT_GD_CONFIG))
     f.close()
-  if not os.path.isfile(src):
-    raise Exception(f'Could not create temp file: {DEFAULT_GROUNDING_DINO_CONFIG_PATH_TMP}')
-  return src
+  if not os.path.isfile(sane):
+    raise Exception(f'Could not create temp file: {sane}')
+  return sane
 
 
-def cleanup_gdconfig_tmpfile(src=DEFAULT_GROUNDING_DINO_CONFIG_PATH_TMP):
-  print(f'Cleaning up temp GroundingDINO config file at: {src} ...')
-  if os.path.isfile(src):
-    os.remove(src)
+def cleanup_gdconfig_file(src=DEFAULT_GROUNDING_DINO_CONFIG_PATH):
+  sane = os.path.abspath(os.path.normpath(src))
+  print(f'Cleaning up GroundingDINO config file at: {sane} ...')
+  if os.path.isfile(sane):
+    os.remove(sane)
 
 
 DEFAULT_GD_CONFIG = '''

--- a/src/ezsam/cli/models.py
+++ b/src/ezsam/cli/models.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from ezsam.cli.config.defaults import DEFAULT_CACHE_FOLDER_LOCATION
+
 
 class Model(str, Enum):
   vit_h = 'vit_h'
@@ -23,21 +25,29 @@ MODEL_URL = {
   Model.gd: 'https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth',
 }
 
-
-DEFAULT_MODEL_LOCATION = {
-  Model.vit_h: './models/sam_vit_h_4b8939.pth',
-  Model.vit_l: './models/sam_vit_l_0b3195.pth',
-  Model.vit_b: './models/sam_vit_b_01ec64.pth',
-  Model.hq_vit_h: './models/sam_hq_vit_h.pth',
-  Model.hq_vit_l: './models/sam_hq_vit_l.pth',
-  Model.hq_vit_b: './models/sam_hq_vit_b.pth',
-  Model.hq_vit_tiny: './models/sam_hq_vit_tiny.pth',
-  Model.gd: './models/groundingdino_swint_ogc.pth',
+MODEL_FILE_BASENAME = {
+  Model.vit_h: 'sam_vit_h_4b8939',
+  Model.vit_l: 'sam_vit_l_0b3195',
+  Model.vit_b: 'sam_vit_b_01ec64',
+  Model.hq_vit_h: 'sam_hq_vit_h',
+  Model.hq_vit_l: 'sam_hq_vit_l',
+  Model.hq_vit_b: 'sam_hq_vit_b',
+  Model.hq_vit_tiny: 'sam_hq_vit_tiny',
+  Model.gd: 'groundingdino_swint_ogc',
 }
 
+MODEL_SEARCH_LOCATIONS = [
+  DEFAULT_CACHE_FOLDER_LOCATION,
+  '.',
+]
 
-def get_default_path_from_model(model: Model) -> str:
-  path = DEFAULT_MODEL_LOCATION[model]
-  if not path:
+
+def default_model_locations(model: Model) -> list[str]:
+  return [f'{search_path}/models/{MODEL_FILE_BASENAME[model]}.pth' for search_path in MODEL_SEARCH_LOCATIONS]
+
+
+def get_default_paths_from_model(model: Model) -> str:
+  paths = default_model_locations(model)
+  if not paths or len(paths) <= 0:
     raise ValueError(f'Invalid model: {model}')
-  return path
+  return paths


### PR DESCRIPTION
Closes #20 

Adds support for reusing cached models and GroundingDINO config files. Previously, models were only reused if in `./models` and config files were temporarily generated if not found.

Now, if the user doesn't specify SAM or GroundingDINO model locations, checks for models in `~/.cache/ezsam/models` (more precisely: pathlib.Path.home().as_posix() + '/models') or `./models` and downloads to cache folder if necessary.

If the user doesn't specify GroundingDINO config, checks for (and generates if necessary) GroundingDINO config files in `~/.cache/ezsam/GroundingDINO_SwinT_OGC.py`.