### PR TITLE
42 make workflow broken

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -25,6 +25,19 @@ on:
         description: 'Directory containing assets to embed into the executable'
         required: true
         default: 'src/ezsam/gui/assets'
+      all_platforms:
+        description: 'Run workflow on all supported platforms'
+        required: true
+        type: boolean
+        default: true
+      platform:
+        description: 'Single platform to use if not all platforms'
+        required: true
+        type: choice
+        options:
+          - ubuntu-latest
+          - windows-latest
+        default: ubuntu-latest
 
 concurrency:
   group: 'make'
@@ -36,59 +49,74 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: ${{ github.event.inputs.all_platforms != 'true' && github.event.inputs.platform != 'ubuntu-latest' && 'ubuntu-latest' }}
+          - os: ${{ github.event.inputs.all_platforms != 'true' && github.event.inputs.platform != 'windows-latest' && 'windows-latest' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Setup pdm
+        uses: pdm-project/setup-pdm@v4
+      - name: Restore cached venv
+        id: cache-venv-restore
+        uses: actions/cache/restore@v4
         with:
-          python-version: 3.11
-          architecture: 'x64'
-          cache: 'pip'
-          cache-dependency-path: |
-            **/requirements*.txt
+          path: |
+            .venv
+          key: ${{ runner.os }}-venv
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-      - name: Build executable with Nuitka
-        uses: Nuitka/Nuitka-Action@main
+          pdm install-all
+        shell: bash
+      - name: Save venv to cache
+        id: cache-venv-save
+        uses: actions/cache/save@v4
         with:
-          # ref: https://github.com/Nuitka/Nuitka-Action/blob/main/action.yml
-          nuitka-version: main
-          enable-plugins: tk-inter
-          onefile: true
-          onefile-tempdir-spec: '{TEMP}/${{ github.event.inputs.name }}'
-          include-data-dir: ${{ github.event.inputs.datadir }}=${{ github.event.inputs.datadir }}
-          product-name: ${{ github.event.inputs.name }}
-          product-version: ${{ github.event.inputs.version }}
-          file-version: ${{ github.event.inputs.version }}
-          file-description: ${{ github.event.inputs.description }}
-          output-dir: dist
-          script-name: ${{ github.event.inputs.scriptname }}
+          path: |
+            .venv
+          key: ${{ steps.cache-venv-restore.outputs.cache-primary-key }}
+      - name: Build executable with Nuitka
+        run: |
+          pdm make-nuitka "${{ github.event.inputs.name }}" "${{ github.event.inputs.scriptname }}" \
+            "${{ github.event.inputs.version }}" dist \
+            "${{ github.event.inputs.datadir }}" "${{ github.event.inputs.description }}"
+        shell: bash
       - name: Fix executable
-        # Rename executable from script name to desired name.
-        # Remove .bin extension and preserve permissions on Linux.
+        # Preserve executable permissions on Linux.
         # ref: https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
         # ref: https://stackoverflow.com/a/57948488
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            chmod +x dist/*.bin
-            mv dist/*.bin dist/${{ github.event.inputs.name }}
             cd dist
+            tar -cvf ${{ github.event.inputs.name }}-${{ github.event.inputs.version }}.tar ${{ github.event.inputs.name }}-${{ github.event.inputs.version }}
+            rm -rf ${{ github.event.inputs.name }}-${{ github.event.inputs.version }}
+            cd onefile
             tar -cvf ${{ github.event.inputs.name }}.tar ${{ github.event.inputs.name }}
-            cd ..
+            cd ../..
           elif [ "$RUNNER_OS" == "Windows" ]; then
-            mv dist/*.exe dist/${{ github.event.inputs.name }}.exe
-          else
-            echo "$RUNNER_OS not supported"
-            exit 1
+            echo "Nothing to fix"
           fi
         shell: bash
-      - name: Upload artifacts
+      - name: Upload standalone archive
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.inputs.name }}-${{ github.event.inputs.version }}-${{ runner.os }}
           path: |
-            dist/*.exe
-            dist/*.tar
+            dist/${{ github.event.inputs.name }}-${{ github.event.inputs.version }}.tar
+            dist/${{ github.event.inputs.name }}-${{ github.event.inputs.version }}/
+      - name: Upload onefile executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.inputs.name }}-${{ github.event.inputs.version }}-${{ runner.os }}-onefile
+          path: |
+            dist/onefile/*.tar
+            dist/onefile/*.exe
+          compression-level: 0
+      - name: Upload onefile executable checksum
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.inputs.name }}-${{ github.event.inputs.version }}-${{ runner.os }}-onefile-checksum
+          path: |
+            dist/onefile/*.sha256
+          compression-level: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@ on:
         default: '0.0.0'
       test:
         description: 'Only publish to test PyPI repository?'
+        type: boolean
         required: true
-        default: 'true'
+        default: true
 
 # Allow only one concurrent deployment
 concurrency:

--- a/make-nuitka.sh
+++ b/make-nuitka.sh
@@ -3,6 +3,10 @@
 name="${1}"
 entrypoint="${2}"
 version="${3}"
+dist="${4}"
+assets="${5}"
+description="${6}"
+CI="${7}"
 if [ -z "${name}" ]; then
   name="ezsam"
 fi
@@ -12,13 +16,19 @@ fi
 if [ -z "${version}" ]; then
   version="0.0.0"
 fi
-assets="src/ezsam/gui/assets"
-description='ezsam is a tool to extract objects from images or video via text prompt - info at https://www.ezsam.org'
-dist="dist-nuitka"
-tempdir="{TEMP}/ezsam"
-outfile="${name}-${version}.bin"
+if [ -z "${dist}" ]; then
+  dist="dist-nuitka"
+fi
+if [ -z "${assets}" ]; then
+  assets="src/ezsam/gui/assets"
+fi
+if [ -z "${description}" ]; then
+  description='ezsam is a tool to extract objects from images or video via text prompt - info at https://www.ezsam.org'
+fi
+tempdir="{TEMP}/ezsam"  # Should match ezsam.lib.config.EXECUTABLE_NAME
+outfile="${name}"
 echo "Creating ${name}-${version} at `date` ..."
-python -m nuitka --enable-plugin=tk-inter --onefile \
+python -m nuitka --enable-plugin=tk-inter --onefile --assume-yes-for-downloads --disable-console \
   --onefile-tempdir-spec="${tempdir}" \
   --include-data-dir="${assets}=${assets}" \
   --output-filename="${outfile}" \
@@ -26,8 +36,23 @@ python -m nuitka --enable-plugin=tk-inter --onefile \
   --file-version="${version}" \
   --file-description="${description}" \
   --output-dir="${dist}" "${entrypoint}"
-cd dist
-# Note: Nuitka default compression almost as good as 7z
+# Move onefile executable to different folder and checksum
+cd "${dist}"
+mkdir -p "onefile"
+mv "${outfile}" "onefile/${outfile}"
+cd onefile
 sha256sum "${outfile}" > "${outfile}.sha256"
+cd ..
+base=`basename ${entrypoint} .py`
+# In CI, we will zip upload the renamed standalone output directory
+outdir="${name}-${version}"
+mv "${base}.dist" "${outdir}"
+if [ ! -z "${CI}" ]; then
+  # For local builds we have zip and want to just directly create a useful archive and checksum
+  zip -r "${outdir}.zip" "${outdir}"
+  sha256sum "${outdir}.zip" > "${outdir}.zip.sha256"
+  # Now that we have our archive undo move to prevent future runs of Nuikta from failing
+  mv "${outdir}" "${base}.dist" 
+fi
 cd ..
 echo "Finished creating ${name}-${version} at `date`"

--- a/src/ezsam/lib/config.py
+++ b/src/ezsam/lib/config.py
@@ -1,1 +1,2 @@
 LOG_LEVEL = 'normal'  # 'debug'
+EXECUTABLE_NAME = 'ezsam'

--- a/src/ezsam/lib/path.py
+++ b/src/ezsam/lib/path.py
@@ -5,6 +5,7 @@ import os
 import sys
 import tempfile
 
+from ezsam.lib.config import EXECUTABLE_NAME
 from ezsam.lib.logger import debug, warn
 
 
@@ -21,7 +22,7 @@ def resource_path(relative_path: str) -> str:
   #    Another example, using persistence: {CACHE_DIR}/{PRODUCT}/{VERSION}
   try:
     temp = tempfile.gettempdir()
-    base_path = f'{temp}/ezsam'
+    base_path = f'{temp}/{EXECUTABLE_NAME}'
     path = os.path.normpath(os.path.join(base_path, relative_path))
     open(path)
   except FileNotFoundError:

--- a/tests/nuitka-test-advanced.py
+++ b/tests/nuitka-test-advanced.py
@@ -1,21 +1,6 @@
 # Test file only (not up-to-date with gui/app.py) to quickly check if nuitka can build an executable successfully.
 # This file is *much* quicker to test because it does not link against ezsam.cli (and thus skips a lot of the heavier ML libraries).
 
-# nuitka-project-if: {OS} in ("Windows", "Linux", "FreeBSD"):
-#    nuitka-project: --onefile
-# nuitka-project-if: {OS} == "Darwin":
-#    nuitka-project: --standalone
-#    nuitka-project: --macos-create-app-bundle
-# nuitka-project: --enable-plugin=tk-inter
-# nuitka-project: --onefile
-# nuitka-project: --onefile-tempdir-spec="{TEMP}/ezsam"
-# nuitka-project: --include-data-dir="src/ezsam/gui/assets=src/ezsam/gui/assets"
-# nuitka-project: --output-filename=ntestadv-0.0.0.bin
-# nuitka-project: --product-version=0.0.0
-# nuitka-project: --file-version=0.0.0
-# nuitka-project: --file-description="Test building custom tkinter dnd app with bundled resources"
-# nuitka-project: --output-dir=dist
-
 import sys
 import threading
 import tkinter as tk


### PR DESCRIPTION
Fixes #42 

Switching the workflow to the same pdm-based run script as used in local building works in GitHub Actions, producing working binaries. Also adds a couple Nuitka options to fix Windows builds.